### PR TITLE
Feat: Enable switching between UI Thread and Multi Process modes

### DIFF
--- a/app/src/androidMain/python/repl/kernel/kernel_android.py
+++ b/app/src/androidMain/python/repl/kernel/kernel_android.py
@@ -183,7 +183,7 @@ class InAppLocalPrivateProvisioner(provisioning.local_provisioner.LocalProvision
             :return: The process info if the kernel is running, None otherwise
             """
             activity_manager = app.getSystemService(app.ACTIVITY_SERVICE)
-            for p_info in activity_manager.getRunningAppProcesses(Integer.MAX_VALUE).toArray():
+            for p_info in activity_manager.getRunningAppProcesses().toArray():
                 if ":".join(["", *p_info.processName.split(":")[1:]]) == f":kernel{self.process_name}":
                     return p_info
             return None
@@ -252,4 +252,4 @@ class InAppLocalPrivateProvisioner(provisioning.local_provisioner.LocalProvision
         return self.connection_info
 
 
-#provisioning.LocalProvisioner = InAppLocalPrivateProvisioner
+provisioning.LocalProvisioner = InAppLocalPrivateProvisioner

--- a/app/src/commonMain/python/repl/__init__.py
+++ b/app/src/commonMain/python/repl/__init__.py
@@ -1,5 +1,5 @@
 from .config import REPLConfig
-from .server import run_lab_server, send_server_launch_intent
+from .server import run_lab_server, send_server_launch_intent, send_server_stop_intent
 
 import signal
 

--- a/app/src/commonMain/python/repl/server.py
+++ b/app/src/commonMain/python/repl/server.py
@@ -22,3 +22,7 @@ def send_server_launch_intent(context, config: REPLConfig):
     for key, value in config.dict.items():
         intent.putExtra(key, value)
     context.startService(intent)
+
+def send_server_stop_intent(context):
+    intent = Intent(context, InAppLabServerService.getClass())
+    context.stopService(intent)


### PR DESCRIPTION
### Changes
- Add ability to switch between UI Thread and Multi Process modes
- Modify to terminate existing server before restarting a Jupyter Lab server for stable mode transition
- Improve kernel management stability by terminating UI Thread when UIThreadKernelService is running during onclick=run_jupyter execution